### PR TITLE
students テーブルを作成し、5件のデータをINSERT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,33 @@ java {
 		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
+configurations {
+	compleOnly{
+		extendsFrom annotationProcessor
+	}
+}
 
 repositories {
 	mavenCentral()
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	//便利機能、ユーティリティ。Apache Commons Lang
+	implementation("org.apache.commons:commons-lang3:3.17.0")
+
+	//Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	//MySQLドライバ
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//MyBatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/raisetech/StudentManagement/Student.java
+++ b/src/main/java/raisetech/StudentManagement/Student.java
@@ -1,0 +1,21 @@
+package raisetech.StudentManagement;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Student {
+
+  private String id;
+  private String name;
+  private String kanaName;
+  private String nickname;
+  private String email;
+  private String area;
+  private int age;
+  private String sex;
+
+
+
+}

--- a/src/main/java/raisetech/StudentManagement/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/StudentCourse.java
@@ -1,0 +1,18 @@
+package raisetech.StudentManagement;
+
+import java.sql.Timestamp;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudentCourse {
+
+  private String id;
+  private String studentId;
+  private String courseName;
+  private Timestamp courseStartAt;
+  private Timestamp courseEndAt;
+
+
+}

--- a/src/main/java/raisetech/StudentManagement/StudentCourseRepository.java
+++ b/src/main/java/raisetech/StudentManagement/StudentCourseRepository.java
@@ -1,0 +1,13 @@
+package raisetech.StudentManagement;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface StudentCourseRepository {
+
+  @Select("SELECT * FROM students_courses")
+  List<StudentCourse> findAll();
+
+}

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -1,13 +1,35 @@
 package raisetech.StudentManagement;
 
+import java.util.List;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
+@MapperScan("raisetech.StudentManagement")
+@RestController
 public class StudentManagementApplication {
+
+	@Autowired
+	private StudentRepository repository;
+	@Autowired
+	private StudentCourseRepository courseRepository;
 
 	public static void main(String[] args) {
 		SpringApplication.run(StudentManagementApplication.class, args);
+	}
+
+	@GetMapping("/studentList")
+	public List<Student> getStudentList(){
+		return repository.search();
+	}
+
+	@GetMapping("/studentCourseList")
+	public List<StudentCourse> getCourseList(){
+		return courseRepository.findAll();
 	}
 
 }

--- a/src/main/java/raisetech/StudentManagement/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/StudentRepository.java
@@ -1,0 +1,14 @@
+package raisetech.StudentManagement;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface StudentRepository {
+
+  @Select("SELECT * FROM students")
+  List<Student> search();
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=StudentManagement
+
+spring.datasource.url=jdbc:mysql://localhost:3306/StudentManagement
+spring.datasource.username=amichi
+spring.datasource.password=13460314zX
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+mybatis.configuration.map-underscore-to-camel-case=true
+spring.jackson.time-zone=Asia/Tokyo


### PR DESCRIPTION
students_courses テーブルを作成し、5件のデータをINSERT（講座内容＋期間付き）

Studentクラスを作成（Lombok使用）

StudentCourseクラスを作成（Lombok＋Timestamp対応）

MyBatisで StudentRepository 作成 → /studentList エンドポイント実装

MyBatisで StudentCourseRepository 作成 → /studentCourseList エンドポイント実装

application.properties の datasource・MyBatis設定修正（camel-case対応）

文字化け調査（IntelliJのターミナル結果 vs curlブラウザ出力の違い）

タイムゾーン（UTC→JST）に修正して日本時間で出力されるように対応