### PR TITLE
add: Swagger用注釈の追加とAPIドキュメントの整備

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,13 @@ dependencies {
 	//Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+
+	//OpenAPI Generator
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+
 	//便利機能、ユーティリティ。Apache Commons Lang
-	implementation("org.apache.commons:commons-lang3:3.17.0")
+	implementation 'org.apache.commons:commons-lang3:3.17.0'
 
 	//Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -1,11 +1,13 @@
 package raisetech.StudentManagement;
 
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-
+@OpenAPIDefinition(info = @Info(title = "受講生管理システム"))
 @SpringBootApplication
 @MapperScan("raisetech.StudentManagement")
 public class StudentManagementApplication {

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -1,12 +1,12 @@
 package raisetech.StudentManagement.controller;
 
-
-import jakarta.validation.constraints.NotBlank;
-import java.util.Arrays;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.ui.Model;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import raisetech.StudentManagement.data.StudentsCourses;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.exception.TestException;
 import raisetech.StudentManagement.service.StudentService;
@@ -31,7 +30,7 @@ public class StudentController {
   /**
    * コストラクタ
    *
-   * @param service　受講生サービス
+   * @param service 　受講生サービス
    */
   @Autowired
   public StudentController(StudentService service) {
@@ -39,55 +38,68 @@ public class StudentController {
   }
 
   /**
-   * 受講生詳細の一覧検索です。
-   * 全件検索を行うので、条件指定は行わないものになります。
+   * 受講生詳細の一覧検索です。 全件検索を行うので、条件指定は行わないものになります。
    *
    * @return 受講生詳細一覧（全件）
    */
+  @Operation(summary = "一覧検索", description = "受講生の一覧を検索します。")
   @GetMapping("/studentList")
   public List<StudentDetail> getStudentList() {
     return service.searchStudentList();
   }
 
   /**
-   * 受講生詳細検索です。
-   * IDに紐づく任意の受講生の情報を取得します。
+   * 受講生詳細検索です。 IDに紐づく任意の受講生の情報を取得します。
    *
-   * @param id　受講生ID
+   * @param id 　受講生ID
    * @return 受講生詳細
    */
+  @Operation(summary = "受講生詳細検索", description = "受講生詳細の検索をします。",
+      parameters = {@Parameter(name = "id", description = "受講生のID", required = true)
+      },
+      responses = {
+          @ApiResponse(responseCode = "200", description = "正常に取得"),
+          @ApiResponse(responseCode = "404", description = "対象の受講生が存在しない"),
+          @ApiResponse(responseCode = "500", description = "サーバー内部エラー")
+      }
+  )
   @GetMapping("/student/{id}")
-  public StudentDetail getStudent(@PathVariable @NotBlank int id) {
+  public StudentDetail getStudent(@PathVariable int id) {
     return service.searchStudent(id);
   }
 
-  @GetMapping("/newStudent")
-  public String newStudent(Model model) {
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudentCourseList(Arrays.asList(new StudentsCourses()));
-    model.addAttribute("studentDetail", studentDetail);
-    return "registerStudent";
-  }
-
   /**
-   *受講生詳細の登録を行います。
-   * @param studentDetail　受講生詳細
+   * 受講生詳細の登録を行います。
+   *
+   * @param studentDetail 　受講生詳細
    * @return 実行結果
    */
 
+  @Operation(summary = "受講生登録", description = "受講生の登録をします。",
+      responses = {
+          @ApiResponse(responseCode = "201", description = "正常に登録"),
+          @ApiResponse(responseCode = "400", description = "入力値が不正です。"),
+          @ApiResponse(responseCode = "500", description = "サーバー内部エラー")
+      })
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudent(@RequestBody StudentDetail studentDetail) {
     StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
-    return ResponseEntity.ok(responseStudentDetail);
+    return ResponseEntity.status(HttpStatus.CREATED).body(responseStudentDetail);
   }
 
 
   /**
-   *受講生詳細の更新を行う。
-   * キャンセルフラグの更新もここで行います。（論理削除）
-   * @param studentDetail　受講生詳細　
+   * 受講生詳細の更新を行う。 キャンセルフラグの更新もここで行います。（論理削除）
+   *
+   * @param studentDetail 　受講生詳細
    * @return 実行結果
    */
+  @Operation(summary = "受講生更新", description = "受講生の更新をします。",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "正常に更新できました。"),
+          @ApiResponse(responseCode = "400", description = "入力値が不正です。"),
+          @ApiResponse(responseCode = "500", description = "サーバー内部エラー")
+      })
   @PutMapping("/updateStudent")
   public ResponseEntity<String> updateStudent(@RequestBody StudentDetail studentDetail) {
     System.out.println(studentDetail.getStudent());
@@ -95,6 +107,7 @@ public class StudentController {
     return ResponseEntity.ok("更新処理が成功しました。");
   }
 
+  @Operation(summary = "エラーテスト", description = "テスト用エラーです。")
   @GetMapping("/test-error")
   public String testError() throws TestException {
     throw new TestException("これはテスト用の例外です。");

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -1,29 +1,45 @@
 package raisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
+@Schema(description = "受講生詳細")
 @Getter
 @Setter
 public class Student {
 
+
+  @Schema(description = "受講生ID", example = "101")
   private int id;
+
   @NotBlank
   private String name;
+
   @NotBlank
   private String kanaName;
+
   @NotBlank
   private String nickname;
+
   @NotBlank
   @Email
   private String email;
+
+  @Schema(description = "地域（都道府県）", example = "東京")
   @NotBlank
   private String area;
+
   private int age;
+
   @NotBlank
   private String sex;
+
+  @Schema(description = "備考・自由記入欄", example = "特になし")
   private String remark;
+
+  @Schema(description = "論理削除フラグ（true＝削除済み）", example = "false")
   private boolean isDeleted;
 }

--- a/src/main/java/raisetech/StudentManagement/data/StudentsCourses.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentsCourses.java
@@ -1,9 +1,11 @@
 package raisetech.StudentManagement.data;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
+@Schema(description = "受講生コース情報")
 @Getter
 @Setter
 public class StudentsCourses {

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentsCourses;
 
+@Schema(description = "受講生詳細")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
- @Operation、@ApiResponse、@Parameterを各エンドポイントに追加
- Studentクラスに@Schemaを付与し、各フィールドに説明と例を追加
- 登録APIのステータスコードを201 Createdに修正
- Swagger UIの表示を確認（/swagger-ui/index.html）
- OpenAPI Generator用の依存関係をbuild.gradleに追加
